### PR TITLE
Fix CopyObject with MetadataDirective.REPLACE and refactor code

### DIFF
--- a/local-s3-core/src/main/java/com/robothy/s3/core/model/request/CopyObjectOptions.java
+++ b/local-s3-core/src/main/java/com/robothy/s3/core/model/request/CopyObjectOptions.java
@@ -1,5 +1,7 @@
 package com.robothy.s3.core.model.request;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -10,14 +12,40 @@ import lombok.Getter;
 @EqualsAndHashCode
 public class CopyObjectOptions {
 
+  /**
+   * Metadata directive for copy operation.
+   */
+  public enum MetadataDirective {
+    /**
+     * Copy metadata from source object (default).
+     */
+    COPY,
+
+    /**
+     * Replace with metadata provided in the request.
+     */
+    REPLACE
+  }
+
   private String sourceBucket;
 
   private String sourceKey;
 
   private String sourceVersion;
 
+  private MetadataDirective metadataDirective;
+
+  private Map<String, String> userMetadata;
+
   public Optional<String> getSourceVersion() {
     return Optional.ofNullable(sourceVersion);
   }
 
+  public MetadataDirective getMetadataDirective() {
+    return metadataDirective != null ? metadataDirective : MetadataDirective.COPY;
+  }
+
+  public Map<String, String> getUserMetadata() {
+    return userMetadata != null ? userMetadata : Collections.emptyMap();
+  }
 }

--- a/local-s3-core/src/main/java/com/robothy/s3/core/service/CopyObjectService.java
+++ b/local-s3-core/src/main/java/com/robothy/s3/core/service/CopyObjectService.java
@@ -8,6 +8,7 @@ import com.robothy.s3.core.model.answers.PutObjectAns;
 import com.robothy.s3.core.model.request.CopyObjectOptions;
 import com.robothy.s3.core.model.request.GetObjectOptions;
 import com.robothy.s3.core.model.request.PutObjectOptions;
+import java.util.Map;
 
 public interface CopyObjectService extends GetObjectService, PutObjectService, LocalS3MetadataApplicable, StorageApplicable {
 
@@ -30,11 +31,21 @@ public interface CopyObjectService extends GetObjectService, PutObjectService, L
       throw new IllegalArgumentException("The source of a copy request may not specifically refer to a delete marker by version id.");
     }
 
+    // Determine which metadata to use based on the metadata directive
+    Map<String, String> metadataToUse;
+    if (options.getMetadataDirective() == CopyObjectOptions.MetadataDirective.REPLACE) {
+      // Use the metadata provided in the request
+      metadataToUse = options.getUserMetadata();
+    } else {
+      // Use the metadata from the source object
+      metadataToUse = srcObjectAns.getUserMetadata();
+    }
+
     PutObjectAns putObjectAns = putObject(bucket, key, PutObjectOptions.builder()
         .content(srcObjectAns.getContent())
         .contentType(srcObjectAns.getContentType())
         .size(srcObjectAns.getSize())
-        .userMetadata(srcObjectAns.getUserMetadata())
+        .userMetadata(metadataToUse)
         .build());
 
     return CopyObjectAns.builder()

--- a/local-s3-rest/src/main/java/com/robothy/s3/rest/constants/AmzHeaderNames.java
+++ b/local-s3-rest/src/main/java/com/robothy/s3/rest/constants/AmzHeaderNames.java
@@ -32,6 +32,12 @@ public class AmzHeaderNames {
   public static final String X_AMZ_COPY_SOURCE_VERSION_ID = "x-amz-copy-source-version-id";
 
   /**
+   * Specifies whether the metadata is copied from the source object or replaced with metadata
+   * provided in the request. Valid values: COPY, REPLACE. Default: COPY.
+   */
+  public static final String X_AMZ_METADATA_DIRECTIVE = "x-amz-metadata-directive";
+
+  /**
    * The prefix for <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html#UserMetadata">user-defined object metadata</a> keys.
    *
    */

--- a/local-s3-rest/src/test/java/com/robothy/s3/rest/handler/CopyObjectControllerTest.java
+++ b/local-s3-rest/src/test/java/com/robothy/s3/rest/handler/CopyObjectControllerTest.java
@@ -7,8 +7,13 @@ import com.robothy.s3.core.exception.LocalS3InvalidArgumentException;
 import com.robothy.s3.core.model.request.CopyObjectOptions;
 import com.robothy.s3.rest.constants.AmzHeaderNames;
 import com.robothy.s3.rest.service.ServiceFactory;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,6 +33,55 @@ class CopyObjectControllerTest {
     } else {
       assertEquals(result, copyObjectController.parseCopyOptions(request));
     }
+  }
+
+  @Test
+  void testParseMetadataDirectiveAndUserMetadata() {
+    ServiceFactory serviceFactory = Mockito.mock(ServiceFactory.class);
+    CopyObjectController copyObjectController = new CopyObjectController(serviceFactory);
+
+    // Test REPLACE directive with user metadata
+    HttpRequest request = HttpRequest.builder().build();
+    request.getHeaders().put(AmzHeaderNames.X_AMZ_COPY_SOURCE, "/my-bucket/a.txt");
+    request.getHeaders().put(AmzHeaderNames.X_AMZ_METADATA_DIRECTIVE, "REPLACE");
+    request.getHeaders().put(AmzHeaderNames.X_AMZ_META_PREFIX + "key1", "value1");
+    request.getHeaders().put(AmzHeaderNames.X_AMZ_META_PREFIX + "key2", "value2");
+
+    Map<String, String> expectedMetadata = new HashMap<>();
+    expectedMetadata.put("key1", "value1");
+    expectedMetadata.put("key2", "value2");
+
+    CopyObjectOptions options = copyObjectController.parseCopyOptions(request);
+    assertEquals(CopyObjectOptions.MetadataDirective.REPLACE, options.getMetadataDirective());
+    assertEquals(expectedMetadata, options.getUserMetadata());
+
+    // Test COPY directive (no user metadata should be parsed)
+    request = HttpRequest.builder().build();
+    request.getHeaders().put(AmzHeaderNames.X_AMZ_COPY_SOURCE, "/my-bucket/a.txt");
+    request.getHeaders().put(AmzHeaderNames.X_AMZ_METADATA_DIRECTIVE, "COPY");
+    request.getHeaders().put(AmzHeaderNames.X_AMZ_META_PREFIX + "key3", "value3");
+
+    options = copyObjectController.parseCopyOptions(request);
+    assertEquals(CopyObjectOptions.MetadataDirective.COPY, options.getMetadataDirective());
+    assertEquals(Collections.emptyMap(), options.getUserMetadata());
+
+    // Test default directive (should be COPY)
+    request = HttpRequest.builder().build();
+    request.getHeaders().put(AmzHeaderNames.X_AMZ_COPY_SOURCE, "/my-bucket/a.txt");
+    options = copyObjectController.parseCopyOptions(request);
+    assertEquals(CopyObjectOptions.MetadataDirective.COPY, options.getMetadataDirective());
+  }
+
+  @Test
+  void testInvalidMetadataDirective() {
+    ServiceFactory serviceFactory = Mockito.mock(ServiceFactory.class);
+    CopyObjectController copyObjectController = new CopyObjectController(serviceFactory);
+
+    HttpRequest request = HttpRequest.builder().build();
+    request.getHeaders().put(AmzHeaderNames.X_AMZ_COPY_SOURCE, "/my-bucket/a.txt");
+    request.getHeaders().put(AmzHeaderNames.X_AMZ_METADATA_DIRECTIVE, "INVALID");
+
+    assertThrows(LocalS3InvalidArgumentException.class, () -> copyObjectController.parseCopyOptions(request));
   }
 
   static Stream<Arguments> copySources() {


### PR DESCRIPTION
- Fixed issue #188: When using CopyObject with MetadataDirective.REPLACE, the destination object now correctly uses metadata from the request
- Added support for x-amz-metadata-directive header in CopyObjectController
- Extended CopyObjectOptions to include metadataDirective and userMetadata
- Updated CopyObjectService to apply correct metadata based on directive
- Refactored CopyObjectController.parseCopyOptions into smaller focused methods
- Added unit and integration tests for both COPY and REPLACE directives