### PR TITLE
Return distanceMetric in QueryVectors response

### DIFF
--- a/local-s3-core/src/main/java/com/robothy/s3/core/service/s3vectors/QueryVectorsService.java
+++ b/local-s3-core/src/main/java/com/robothy/s3/core/service/s3vectors/QueryVectorsService.java
@@ -8,6 +8,7 @@ import com.robothy.s3.core.exception.vectors.LocalS3VectorErrorType;
 import com.robothy.s3.core.model.internal.s3vectors.VectorBucketMetadata;
 import com.robothy.s3.core.model.internal.s3vectors.VectorIndexMetadata;
 import com.robothy.s3.core.model.internal.s3vectors.VectorObjectMetadata;
+import com.robothy.s3.datatypes.s3vectors.DistanceMetric;
 import com.robothy.s3.datatypes.s3vectors.request.PutInputVector;
 import com.robothy.s3.datatypes.s3vectors.response.QueryVectorsResponse;
 import com.robothy.s3.datatypes.s3vectors.response.QueryOutputVector;
@@ -28,7 +29,7 @@ public interface QueryVectorsService extends S3VectorsMetadataAware, S3VectorsSt
         List<VectorObjectMetadata> candidateVectors = getCandidateVectors(indexMetadata);
         
         if (candidateVectors.isEmpty()) {
-            return buildEmptyResponse();
+            return buildEmptyResponse(indexMetadata.getDistanceMetric());
         }
 
         List<VectorSearchEngine.VectorSearchResult> searchResults = performVectorSearch(
@@ -36,7 +37,7 @@ public interface QueryVectorsService extends S3VectorsMetadataAware, S3VectorsSt
         
         List<QueryOutputVector> outputVectors = buildOutputVectors(searchResults, returnDistance, returnMetadata);
         
-        return buildResponse(outputVectors);
+        return buildResponse(outputVectors, indexMetadata.getDistanceMetric());
     }
 
     private float[] validateQueryVector(PutInputVector.VectorData queryVector, int indexDimension) {
@@ -69,9 +70,10 @@ public interface QueryVectorsService extends S3VectorsMetadataAware, S3VectorsSt
         return new ArrayList<>(indexMetadata.getVectorObjects().values());
     }
 
-    private QueryVectorsResponse buildEmptyResponse() {
+    private QueryVectorsResponse buildEmptyResponse(DistanceMetric distanceMetric) {
         return QueryVectorsResponse.builder()
             .vectors(new ArrayList<>())
+            .distanceMetric(distanceMetric)
             .build();
     }
 
@@ -127,9 +129,10 @@ public interface QueryVectorsService extends S3VectorsMetadataAware, S3VectorsSt
         return Boolean.TRUE.equals(returnMetadata) && vectorMetadata.getMetadata() != null;
     }
 
-    private QueryVectorsResponse buildResponse(List<QueryOutputVector> outputVectors) {
+    private QueryVectorsResponse buildResponse(List<QueryOutputVector> outputVectors, DistanceMetric distanceMetric) {
         return QueryVectorsResponse.builder()
             .vectors(outputVectors)
+            .distanceMetric(distanceMetric)
             .build();
     }
 }

--- a/local-s3-core/src/test/java/com/robothy/s3/core/service/s3vectors/QueryVectorsServiceTest.java
+++ b/local-s3-core/src/test/java/com/robothy/s3/core/service/s3vectors/QueryVectorsServiceTest.java
@@ -47,6 +47,7 @@ class QueryVectorsServiceTest {
 
     assertNotNull(response);
     assertEquals(2, response.getVectors().size());
+    assertEquals(DistanceMetric.EUCLIDEAN, response.getDistanceMetric());
     
     QueryOutputVector firstResult = response.getVectors().get(0);
     assertEquals("vector1", firstResult.getKey());
@@ -74,6 +75,7 @@ class QueryVectorsServiceTest {
 
     assertNotNull(response);
     assertEquals(1, response.getVectors().size());
+    assertEquals(DistanceMetric.COSINE, response.getDistanceMetric());
     
     QueryOutputVector result = response.getVectors().get(0);
     assertEquals("vector1", result.getKey());
@@ -97,6 +99,7 @@ class QueryVectorsServiceTest {
 
     assertNotNull(response);
     assertTrue(response.getVectors().isEmpty());
+    assertEquals(DistanceMetric.EUCLIDEAN, response.getDistanceMetric());
   }
 
   @Test

--- a/local-s3-datatypes/src/main/java/com/robothy/s3/datatypes/s3vectors/response/QueryVectorsResponse.java
+++ b/local-s3-datatypes/src/main/java/com/robothy/s3/datatypes/s3vectors/response/QueryVectorsResponse.java
@@ -1,6 +1,7 @@
 package com.robothy.s3.datatypes.s3vectors.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.robothy.s3.datatypes.s3vectors.DistanceMetric;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,5 +26,12 @@ public class QueryVectorsResponse {
    */
   @JsonProperty("vectors")
   private List<QueryOutputVector> vectors;
+
+  /**
+   * The distance metric configured for the vector index.
+   * Required: Yes
+   */
+  @JsonProperty("distanceMetric")
+  private DistanceMetric distanceMetric;
 
 }


### PR DESCRIPTION
Hi there, first of all, thanks for your work here!

I was adopting it for a test suite around vector stores (see https://github.com/symfony/ai/pull/2311), but ran into the issue that the SDK we're using is issuing a warning while using it instead of AWS - since i usually try to address issues i find upstream, i wanted to jump on it - i'm not fluent in java tho.

if you don't appreciate ai-assisted contributions, you can basically convert this into an issue and close - just want to offer support, not extra burden.

Cheers Chris

---

Summary + References to relevant docs by Claude Code

---

### Summary

The `QueryVectors` response omits the `distanceMetric` field, although AWS declares it as required in the S3 Vectors API model (`QueryVectorsOutput.required = ["vectors", "distanceMetric"]`). SDKs that follow the model therefore fail or warn while parsing the response - the AWS PHP SDK (async-aws) e.g. emits `Undefined array key "distanceMetric"` on every query.

Before:

```json
{"vectors":[{"distance":0.0,"key":"a","metadata":{"name":"third"}}]}
```

After:

```json
{"vectors":[{"distance":0.0,"key":"a","metadata":{"name":"third"}}],"distanceMetric":"cosine"}
```

### References

* [QueryVectors API reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_QueryVectors.html) lists `distanceMetric` as a response element: *"The distance metric that was used for the similarity search calculation. This is the same distance metric that was configured for the vector index when it was created."* (Type: String, Valid Values: `euclidean | cosine`)
* [S3 Vectors API model](https://github.com/boto/botocore/blob/develop/botocore/data/s3vectors/2025-07-15/service-2.json) declares the field as required, which is why generated SDKs read it unconditionally:

  ```json
  "QueryVectorsOutput": {
    "type": "structure",
    "required": ["vectors", "distanceMetric"],
    ...
  }
  ```